### PR TITLE
Validation on gilt config

### DIFF
--- a/gilt/config.py
+++ b/gilt/config.py
@@ -69,16 +69,21 @@ def _get_config_generator(filename):
     :return: dict
     """
     for d in _get_config(filename):
-        parsedrepo = giturlparse.parse(d.get('git'), False)
+        repo = d['git']
+        parsedrepo = giturlparse.parse(repo)
         name = '{}.{}'.format(parsedrepo.owner, parsedrepo.repo)
         src_dir = os.path.join(_get_clone_dir(), name)
+        files = d.get('files')
+        dst_dir = None
+        if not files:
+            dst_dir = _get_dst_dir(d['dst'])
         yield {
-            'git': d.get('git'),
-            'version': d.get('version'),
+            'git': repo,
+            'version': d['version'],
             'name': name,
             'src': src_dir,
-            'dst': _get_dst_dir(d),
-            'files': _get_files_config(src_dir, d.get('files'))
+            'dst': dst_dir,
+            'files': _get_files_config(src_dir, files)
         }
 
 
@@ -94,8 +99,8 @@ def _get_files_generator(src_dir, files_list):
     if files_list:
         for d in files_list:
             yield {
-                'src': os.path.join(src_dir, d.get('src')),
-                'dst': _get_dst_dir(d)
+                'src': os.path.join(src_dir, d['src']),
+                'dst': _get_dst_dir(d['dst'])
             }
 
 
@@ -114,17 +119,17 @@ def _get_config(filename):
             raise ParseError(msg)
 
 
-def _get_dst_dir(d):
+def _get_dst_dir(dst_dir):
     """
-    Prefix the provided dict's `dst` key with working directory and return a
-    dict.
+    Prefix the provided string with working directory and return a
+    str.
 
-    :param d: A config dict which contains a `dst` key.
+    :param dst_dir: A string to be prefixed with the working dir.
     :return: str
     """
     wd = os.getcwd()
-    if d.get('dst'):
-        return os.path.join(wd, d.get('dst'))
+
+    return os.path.join(wd, dst_dir)
 
 
 def _get_clone_dir():

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -53,6 +53,92 @@ def test_config(gilt_config_file):
     assert ('library', '') == os_split(f.dst)[-2:]
 
 
+@pytest.fixture()
+def missing_git_key_data():
+    return [{'foo': 'https://github.com/retr0h/ansible-etcd.git'}]
+
+
+@pytest.mark.parametrize(
+    'gilt_config_file', ['missing_git_key_data'],
+    indirect=['gilt_config_file'])
+def test_config_missing_git_key(gilt_config_file):
+    with pytest.raises(KeyError):
+        config.config(gilt_config_file)
+
+
+@pytest.fixture()
+def missing_version_key_data():
+    return [{
+        'git': 'https://github.com/retr0h/ansible-etcd.git',
+        'foo': 'master'
+    }]
+
+
+@pytest.mark.parametrize(
+    'gilt_config_file', ['missing_version_key_data'],
+    indirect=['gilt_config_file'])
+def test_config_missing_version_key(gilt_config_file):
+    with pytest.raises(KeyError):
+        config.config(gilt_config_file)
+
+
+@pytest.fixture()
+def missing_dst_key_data():
+    return [{
+        'git': 'https://github.com/retr0h/ansible-etcd.git',
+        'version': 'master',
+        'foo': 'roles/retr0h.ansible-etcd/'
+    }]
+
+
+@pytest.mark.parametrize(
+    'gilt_config_file', ['missing_dst_key_data'],
+    indirect=['gilt_config_file'])
+def test_config_missing_dst_key(gilt_config_file):
+    with pytest.raises(KeyError):
+        config.config(gilt_config_file)
+
+
+@pytest.fixture()
+def missing_files_src_key_data():
+    return [{
+        'git': 'https://github.com/lorin/openstack-ansible-modules.git',
+        'version': 'master',
+        'files': [{
+            'foo': '*_manage',
+            'dst': 'library/'
+        }]
+    }]
+
+
+@pytest.mark.parametrize(
+    'gilt_config_file', ['missing_files_src_key_data'],
+    indirect=['gilt_config_file'])
+def test_config_missing_files_src_key(gilt_config_file):
+    with pytest.raises(KeyError):
+        config.config(gilt_config_file)
+
+
+@pytest.fixture()
+def missing_files_dst_key_data():
+    return [{
+        'git': 'https://github.com/lorin/openstack-ansible-modules.git',
+        'version': 'master',
+        'files': [{
+            'src': '*_manage',
+            'foo': 'library/'
+        }]
+    }]
+
+
+@pytest.mark.parametrize(
+    'gilt_config_file', ['missing_files_dst_key_data'],
+    indirect=['gilt_config_file'])
+def test_config_missing_files_dst_key(gilt_config_file):
+    with pytest.raises(KeyError):
+        config.config(gilt_config_file)
+
+
 @pytest.mark.parametrize(
     'gilt_config_file', ['gilt_data'], indirect=['gilt_config_file'])
 def test_get_config_generator(gilt_config_file):
@@ -63,7 +149,7 @@ def test_get_config_generator(gilt_config_file):
 
 
 def test_get_files_generator(temp_dir):
-    files_list = [{'src': 'foo', 'dest': 'bar'}]
+    files_list = [{'src': 'foo', 'dst': 'bar'}]
     result = [i for i in config._get_files_generator('/tmp/dir', files_list)]
 
     assert isinstance(result, list)
@@ -93,15 +179,9 @@ def test_get_config_handles_parse_error(gilt_config_file):
 
 def test_get_dst_dir(temp_dir):
     os.chdir(temp_dir.strpath)
-    result = config._get_dst_dir({'dst': 'role/foo'})
+    result = config._get_dst_dir('role/foo')
 
     assert os.path.join(temp_dir.strpath, 'role', 'foo') == result
-
-
-def test_get_dst_dir_with_missing_dst(temp_dir):
-    result = config._get_dst_dir({'foo': 'bar'})
-
-    assert result is None
 
 
 def test_get_clone_dir():

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -83,7 +83,7 @@ def test_overlay(mocker, temp_dir):
         mocker.Mock(src=os.path.join(clone_dir, '*_manage'), dst=dst_dir),
         mocker.Mock(src=os.path.join(clone_dir, 'nova_quota'), dst=dst_dir),
         mocker.Mock(src=os.path.join(clone_dir, 'neutron_router'),
-            dst=os.path.join(dst_dir, 'neutron_router.py')),
+                    dst=os.path.join(dst_dir, 'neutron_router.py')),
         mocker.Mock(
             src=os.path.join(clone_dir, 'tests'),
             dst=os.path.join(dst_dir, 'tests'))


### PR DESCRIPTION
We were using dict.get, which silently ignores missing keys.  We want
the user to know when the config is invalid.