### PR TITLE
Added --run-slow to tox

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [report]
 fail_under =
-  70
+  94

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements.txt
     -rtest-requirements.txt
 commands =
-    py.test test/ --cov=gilt {posargs}
+    py.test --runslow test/ --cov=gilt {posargs}
 
 [testenv:syntax]
 deps =


### PR DESCRIPTION
We should run the full suite when executing tox.  Also, updated
coverage minimum to prevent slippage.