### PR TITLE
Clean after checkout

### DIFF
--- a/gilt/git.py
+++ b/gilt/git.py
@@ -108,20 +108,20 @@ def _get_branch(version, debug=False):
     """
     Handle switching to the specified version and return None.
 
-    1. Clean the repository before we begin.
-    2. Fetch the origin.
-    3. Checkout the specified version.
+    1. Fetch the origin.
+    2. Checkout the specified version.
+    3. Clean the repository before we begin.
     4. Pull the origin when a branch; _not_ a commit id.
 
     :param version: A string containing the branch/tag/sha to be exported.
     :param debug: An optional bool to toggle debug output.
     :return: None
     """
-    cmd = sh.git.bake('clean', '-d', '-x', '-f')
-    util.run_command(cmd, debug=debug)
     cmd = sh.git.bake('fetch')
     util.run_command(cmd, debug=debug)
     cmd = sh.git.bake('checkout', version)
+    util.run_command(cmd, debug=debug)
+    cmd = sh.git.bake('clean', '-d', '-x', '-f')
     util.run_command(cmd, debug=debug)
     if not re.match(r'\b[0-9a-f]{7,40}\b', str(version)):
         cmd = sh.git.bake('pull', rebase=True, ff_only=True)

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -106,44 +106,40 @@ def patched_run_command(mocker):
 
 def test_get_branch(mocker, patched_run_command):
     git._get_branch('branch')
+    # yapf: disable
     expected = [
-        mocker.call(
-            sh.git.bake('clean', '-d', '-x', '-f'), debug=False),
-        mocker.call(
-            sh.git.bake('fetch'), debug=False),
-        mocker.call(
-            sh.git.bake('checkout', 'branch'), debug=False),
-        mocker.call(
-            sh.git.bake(
-                'pull', rebase=True, ff_only=True), debug=False),
+        mocker.call(sh.git.bake('fetch'), debug=False),
+        mocker.call(sh.git.bake('checkout', 'branch'), debug=False),
+        mocker.call(sh.git.bake('clean', '-d', '-x', '-f'), debug=False),
+        mocker.call(sh.git.bake('pull', rebase=True, ff_only=True),
+                    debug=False)
     ]
+    # yapf: enable
 
     assert expected == patched_run_command.mock_calls
 
 
 def test_get_branch_does_not_pull_on_sha(mocker, patched_run_command):
     git._get_branch('e14ebe0')
+    # yapf: disable
     expected = [
-        mocker.call(
-            sh.git.bake('clean', '-d', '-x', '-f'), debug=False),
-        mocker.call(
-            sh.git.bake('fetch'), debug=False),
-        mocker.call(
-            sh.git.bake('checkout', 'e14ebe0'), debug=False),
+        mocker.call(sh.git.bake('fetch'), debug=False),
+        mocker.call(sh.git.bake('checkout', 'e14ebe0'), debug=False),
+        mocker.call(sh.git.bake('clean', '-d', '-x', '-f'), debug=False)
     ]
+    # yapf: enable
 
     assert expected == patched_run_command.mock_calls
 
 
 def test_get_branch_handles_int_sha(mocker, patched_run_command):
     git._get_branch(1234567)
+    # yapf: disable
     expected = [
-        mocker.call(
-            sh.git.bake('clean', '-d', '-x', '-f'), debug=False),
-        mocker.call(
-            sh.git.bake('fetch'), debug=False),
-        mocker.call(
-            sh.git.bake('checkout', '1234567'), debug=False),
+        mocker.call(sh.git.bake('fetch'), debug=False),
+        mocker.call(sh.git.bake('checkout', '1234567'), debug=False),
+        mocker.call(sh.git.bake('clean', '-d', '-x', '-f'), debug=False)
     ]
+    # yapf: enable
 
     assert expected == patched_run_command.mock_calls


### PR DESCRIPTION
We should clean after checkout and before pull.  This will ensure
untracked files from a previous version are no longer in the tree.