### PR TITLE
Renamed project

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,12 @@ gilt - A GIT layering tool.
 Quick Start
 ===========
 
+Install gilt using pip:
+
+.. code-block:: bash
+
+  $ pip install gilt-python
+
 Overlay a remote repository into the destination provided.
 
 .. code-block:: bash

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [metadata]
-name = gilt
+name = gilt-python
 summary = gilt - A GIT layering tool.
 description-file = README.rst
 author = John Dewey


### PR DESCRIPTION
Gilt is registered in pypi.  However, was able to get gilt-python
to release his project[1], since it was unused in 5 years.

[1] https://github.com/aellerton/gilt-python/issues/1