### PR TITLE
Fix concurrency bug

### DIFF
--- a/gilt/config.py
+++ b/gilt/config.py
@@ -33,6 +33,9 @@ class ParseError(Exception):
     pass
 
 
+BASE_WORKING_DIR = '~/.gilt'
+
+
 def config(filename):
     """
     Construct `Config` object and return a list.
@@ -41,7 +44,8 @@ def config(filename):
     :return: list
     """
     Config = collections.namedtuple(
-        'Config', ['git', 'version', 'name', 'src', 'dst', 'files'])
+        'Config',
+        ['git', 'lock_file', 'version', 'name', 'src', 'dst', 'files'])
 
     return [Config(**d) for d in _get_config_generator(filename)]
 
@@ -80,6 +84,7 @@ def _get_config_generator(filename):
             dst_dir = _get_dst_dir(d['dst'])
         yield {
             'git': repo,
+            'lock_file': _get_lock_file(name),
             'version': d['version'],
             'name': name,
             'src': src_dir,
@@ -134,15 +139,38 @@ def _get_dst_dir(dst_dir):
     return os.path.join(wd, dst_dir)
 
 
+def _get_lock_file(name):
+    """Return the lock file for the given name."""
+    return os.path.join(
+        _get_lock_dir(),
+        name, )
+
+
+def _get_base_dir():
+    """Return gilt's base working directory."""
+    return os.path.expanduser(BASE_WORKING_DIR)
+
+
+def _get_lock_dir():
+    """
+    Construct gilt's lock directory and return a str.
+
+    :return: str
+    """
+    return os.path.join(
+        _get_base_dir(),
+        'lock', )
+
+
 def _get_clone_dir():
     """
     Construct gilt's clone directory and return a str.
 
     :return: str
     """
-    path = '~/.gilt/clone'
-
-    return os.path.expanduser(path)
+    return os.path.join(
+        _get_base_dir(),
+        'clone', )
 
 
 def _makedirs(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 click
 colorama
+fasteners
 giturlparse.py
 pbr
 PyYAML

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,24 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import setuptools
+from setuptools import setup
 
-setuptools.setup(setup_requires=['pbr'], pbr=True)
+from pip.download import PipSession
+from pip.req import parse_requirements
+
+
+def reqs(path):
+    return [str(r.req) for r in parse_requirements(path, session=PipSession())]
+
+
+INSTALL_REQUIRES = reqs("requirements.txt")
+
+setup(
+    name='gilt',
+    version='0.1',
+    py_modules=['gilt'],
+    install_requires=INSTALL_REQUIRES,
+    entry_points='''
+        [console_scripts]
+        gilt=gilt.shell:main
+    ''', )

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -39,6 +39,8 @@ def test_config(gilt_config_file):
     assert 'master' == r.version
     assert 'retr0h.ansible-etcd' == r.name
     assert ('.gilt', 'clone', 'retr0h.ansible-etcd') == os_split(r.src)[-3:]
+    assert ('.gilt', 'lock', 'retr0h.ansible-etcd'
+            ) == os_split(r.lock_file)[-3:]
     assert ('roles', 'retr0h.ansible-etcd', '') == os_split(r.dst)[-3:]
     assert [] == r.files
 


### PR DESCRIPTION
Add interprocess lock around cloning/extracting operations. This allows multiple gilt processes dealing with the same repos to be running concurrently.

Drive-by: fix setup.py so that gilt can be installed in dev mode in a virtualenv.