### PR TITLE
Removed sphinx.ext.githubpages sphinx extension

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -38,7 +38,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.coverage',
     'sphinx.ext.doctest',
-    'sphinx.ext.githubpages',
     'sphinx.ext.todo',
     'alabaster',
 ]


### PR DESCRIPTION
We are no longer publishing to gh-pages, no need to enable this
extension.