### PR TITLE
Suppress doc building warnings

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -114,6 +114,9 @@ pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
 
+# List of warnings to suppress.
+suppress_warnings = ['image.nonlocal_uri']
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for


### PR DESCRIPTION
We don't need to see the following warnings.

    README.rst:None: WARNING: nonlocal image URI found: https://badge.fury.io/py/gilt-python.svg
    README.rst:None: WARNING: nonlocal image URI found: https://readthedocs.org/projects/gilt/badge/?version=latest