### PR TITLE
Add support to merge directory trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info/
+build/
 *.py[cod]
 .cache/
 .coverage

--- a/gilt/git.py
+++ b/gilt/git.py
@@ -25,7 +25,6 @@ import os
 import shutil
 
 import sh
-
 from gilt import util
 
 
@@ -96,9 +95,13 @@ def overlay(repository, files, version, keepdirs=False, debug=False):
                         version, filename, fc.dst)
                     util.print_info(msg)
             else:
-                if os.path.isdir(fc.dst) and os.path.isdir(fc.src) and not keepdirs:
-                    shutil.rmtree(fc.dst)
-                util.copy(fc.src, fc.dst)
+                if os.path.isdir(fc.dst) and os.path.isdir(
+                        fc.src) and keepdirs:
+                    util.mergetree(fc.src, fc.dst)
+                else:
+                    if os.path.isdir(fc.dst) and os.path.isdir(fc.src):
+                        shutil.rmtree(fc.dst)
+                    util.copy(fc.src, fc.dst)
                 msg = '  - copied ({}) {} to {}'.format(
                     version, fc.src, fc.dst)
                 util.print_info(msg)

--- a/gilt/git.py
+++ b/gilt/git.py
@@ -71,7 +71,7 @@ def extract(repository, destination, version, debug=False):
         util.print_info(msg)
 
 
-def overlay(repository, files, version, debug=False):
+def overlay(repository, files, version, keepdirs=False, debug=False):
     """
     Overlay files from the specified repository/version into the given
     directory and return None.
@@ -80,6 +80,7 @@ def overlay(repository, files, version, debug=False):
      extracted.
     :param files: A list of `FileConfig` objects.
     :param version: A string containing the branch/tag/sha to be exported.
+    :param keepdirs: An optional bool to not delete directories before replacing
     :param debug: An optional bool to toggle debug output.
     :return: None
     """
@@ -95,7 +96,7 @@ def overlay(repository, files, version, debug=False):
                         version, filename, fc.dst)
                     util.print_info(msg)
             else:
-                if os.path.isdir(fc.dst) and os.path.isdir(fc.src):
+                if os.path.isdir(fc.dst) and os.path.isdir(fc.src) and not keepdirs:
                     shutil.rmtree(fc.dst)
                 util.copy(fc.src, fc.dst)
                 msg = '  - copied ({}) {} to {}'.format(

--- a/gilt/shell.py
+++ b/gilt/shell.py
@@ -44,7 +44,7 @@ class NotFoundError(Exception):
     help='Enable or disable debug mode. Default is disabled.')
 @click.option(
     '--keepdirs/--no-keepdirs',
-    default=True,
+    default=False,
     help='Do not remove directories before placing contents into them')
 @click.version_option(version=gilt.__version__)
 @click.pass_context

--- a/gilt/util.py
+++ b/gilt/util.py
@@ -118,5 +118,5 @@ def mergetree(src, dst, symlinks=False, ignore=None):
         if os.path.isdir(s):
             mergetree(s, d, symlinks, ignore)
         else:
-            if not os.path.exists(d):
+            if os.path.exists(d):
                 shutil.copy2(s, d)

--- a/gilt/util.py
+++ b/gilt/util.py
@@ -96,7 +96,7 @@ def copy(src, dst):
         mergetree(src, dst)
     else:
         try:
-            mergetree(src, dst)
+            shutil.copytree(src, dst)
         except OSError as exc:
             if exc.errno == errno.ENOTDIR:
                 shutil.copy(src, dst)

--- a/gilt/util.py
+++ b/gilt/util.py
@@ -92,16 +92,13 @@ def copy(src, dst):
      destination ends with a '/', will copy into the target directory.
     :return: None
     """
-    if os.path.isdir(src) and os.path.isdir(dst):
-        mergetree(src, dst)
-    else:
-        try:
-            shutil.copytree(src, dst)
-        except OSError as exc:
-            if exc.errno == errno.ENOTDIR:
-                shutil.copy(src, dst)
-            else:
-                raise
+    try:
+        shutil.copytree(src, dst)
+    except OSError as exc:
+        if exc.errno == errno.ENOTDIR:
+            shutil.copy(src, dst)
+        else:
+            raise
 
 
 def mergetree(src, dst, symlinks=False, ignore=None):

--- a/gilt/util.py
+++ b/gilt/util.py
@@ -118,6 +118,5 @@ def mergetree(src, dst, symlinks=False, ignore=None):
         if os.path.isdir(s):
             mergetree(s, d, symlinks, ignore)
         else:
-            if not os.path.exists(
-                    d) or os.stat(s).st_mtime - os.stat(d).st_mtime > 1:
+            if not os.path.exists(d):
                 shutil.copy2(s, d)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -49,6 +49,7 @@ def test_config(gilt_config_file):
     assert 'lorin.openstack-ansible-modules' == r.name
     assert 'lorin.openstack-ansible-modules' == os_split(r.src)[-1]
     assert r.dst is None
+
     f = r.files[0]
     x = ('.gilt', 'clone', 'lorin.openstack-ansible-modules', '*_manage')
     assert x == os_split(f.src)[-4:]
@@ -198,8 +199,11 @@ def test_makedirs(temp_dir):
     d = os.path.join(temp_dir.strpath, 'foo')
     assert os.path.isdir(d)
 
-    expected = (7 * 64 + 5 * 8 + 5)  # Octal 755
-    assert expected == (os.lstat(d).st_mode & 0o777)
+    curmask = os.umask(0)
+    os.umask(curmask)
+
+    expected = 0o777 & ~curmask
+    assert expected == (os.stat(d).st_mode & 0o777)
 
 
 def test_makedirs_nested_directory(temp_dir):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -24,7 +24,6 @@ import os
 
 import pytest
 import sh
-
 from gilt import util
 
 
@@ -98,6 +97,23 @@ def test_copy_dir(temp_dir):
     util.copy(src_dir, d)
 
     assert os.path.exists(d)
+
+
+def test_merge_dir(temp_dir):
+    src_dir = os.path.join(temp_dir.strpath, 'src')
+    dst_dir = os.path.join(temp_dir.strpath, 'dst')
+
+    os.mkdir(src_dir)
+    os.mkdir(dst_dir)
+
+    d_file = os.path.join(dst_dir, 'foobar')
+    open(d_file, 'a').close()
+
+    d = os.path.join(dst_dir, 'src')
+    util.mergetree(src_dir, d)
+
+    assert os.path.exists(d)
+    assert os.path.exists(d_file)
 
 
 def test_copy_raises(temp_dir):


### PR DESCRIPTION
This PR implements support for merging directory trees instead of clobbering them. The default of clobber remains, but a new option --keepdirs is introduced. This option will allow files in an existing directory to stay while new files are put in place around them. Additionally only newer files are put in place, to preserve the spirit of 'keepdir'.  Though this is debatable behavior since the git src should be the provider of files and not allow local edits to survive an overlay.