### PR TITLE
Swapped out git url parser

### DIFF
--- a/gilt/config.py
+++ b/gilt/config.py
@@ -86,7 +86,7 @@ def _get_config_generator(filename):
     for d in _get_config(filename):
         repo = d['git']
         parsedrepo = giturlparse.parse(repo)
-        name = '{}.{}'.format(parsedrepo.owner, parsedrepo.repo)
+        name = '{}.{}'.format(parsedrepo.owner, parsedrepo.name)
         src_dir = os.path.join(_get_clone_dir(), name)
         files = d.get('files')
         post_commands = d.get('post_commands', [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 colorama
 fasteners
-giturlparse.py
+git-url-parse
 pbr
 PyYAML
 sh


### PR DESCRIPTION
The previous git url parser was not maintained.  Swapped out for a
basic git url parser maintained by @retr0h.