### PR TITLE
Add option to override gilt's default cache dir

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -51,6 +51,12 @@ Overlay a directory from a remote repository into the destination provided.
 
   $ gilt overlay
 
+Optionally, override gilt's cache location (defaults to ~/.gilt):
+
+.. code-block:: bash
+
+  $ export GILT_CACHE_DIRECTORY=~/my-gilt-cache
+
 Overlay files and a directory and run post-overlay commands.
 
 .. code-block:: yaml

--- a/gilt/config.py
+++ b/gilt/config.py
@@ -33,7 +33,7 @@ class ParseError(Exception):
     pass
 
 
-BASE_WORKING_DIR = '~/.gilt'
+BASE_WORKING_DIR = os.environ.get('GILT_CACHE_DIRECTORY', '~/.gilt')
 
 
 def config(filename):


### PR DESCRIPTION
Introduce an environment variable named 'GILT_CACHE_DIRECTORY' that can used to override the default '~/.gilt' and thus control where gilt puts its cache.