### PR TITLE
Cleanup dst prior to checkout-index

### DIFF
--- a/gilt/git.py
+++ b/gilt/git.py
@@ -61,6 +61,9 @@ def extract(repository, destination, version, debug=False):
     :return: None
     """
     with util.saved_cwd():
+        if os.path.isdir(destination):
+            shutil.rmtree(destination)
+
         os.chdir(repository)
         _get_version(version, debug)
         cmd = sh.git.bake(


### PR DESCRIPTION
Extract can leave files behind. This patch removes the dest
prior to checkout-index.